### PR TITLE
Create additional Intent matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Utilities
 
 - [verifyLinkOpen()](https://github.com/bufferapp/Biscotti/blob/master/app/src/main/java/org/buffer/android/biscotti/BiscottiUtil.kt#L31) - Verify a link is opened after performing an action
 
+- [verifyActivityLaunched()](https://github.com/bufferapp/Biscotti/blob/master/app/src/main/java/org/buffer/android/biscotti/BiscottiUtil.kt#L39) - Verify an Activity with a given name is launched
+
+- [verifyExpectedIntent()](https://github.com/bufferapp/Biscotti/blob/master/app/src/main/java/org/buffer/android/biscotti/BiscottiUtil.kt#L44) - Verify an Intent with a given Matcher is launched
 
 Using Biscotti
 --------------

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ App Shortcuts
 
 - [assertAppShortcutExists()](https://github.com/bufferapp/Biscotti/blob/master/app/src/main/java/org/buffer/android/biscotti/BiscottiShortcuts.kt#L8) - Check that an app shortcut for the given app name, with the given label, exists
 
+Intents
+---------
+
+- [verifyLinkOpen()](https://github.com/bufferapp/Biscotti/blob/master/app/src/main/java/org/buffer/android/biscotti/BiscottiIntents.kt#L16) - Verify a link is opened after performing an action
+
+- [verifyActivityLaunched()](https://github.com/bufferapp/Biscotti/blob/master/app/src/main/java/org/buffer/android/biscotti/BiscottiIntents.kt#L22) - Verify an Activity with a given name is launched
+
+- [verifyExpectedIntent()](https://github.com/bufferapp/Biscotti/blob/master/app/src/main/java/org/buffer/android/biscotti/BiscottiIntents.kt#L27) - Verify an Intent with a given Matcher is launched
+
 Utilities
 ---------
 
@@ -37,12 +46,6 @@ Utilities
 - [changeOrientationToPortrait](https://github.com/bufferapp/Biscotti/blob/master/app/src/main/java/org/buffer/android/biscotti/BiscottiUtil.kt#L15) - Change the test devices orientation to portrait
 
 - [closeSoftKeyboardWithDelay](https://github.com/bufferapp/Biscotti/blob/master/app/src/main/java/org/buffer/android/biscotti/BiscottiUtil.kt#L21) - Close the software keyboard, followed by applying a delay using the given delay value
-
-- [verifyLinkOpen()](https://github.com/bufferapp/Biscotti/blob/master/app/src/main/java/org/buffer/android/biscotti/BiscottiUtil.kt#L31) - Verify a link is opened after performing an action
-
-- [verifyActivityLaunched()](https://github.com/bufferapp/Biscotti/blob/master/app/src/main/java/org/buffer/android/biscotti/BiscottiUtil.kt#L39) - Verify an Activity with a given name is launched
-
-- [verifyExpectedIntent()](https://github.com/bufferapp/Biscotti/blob/master/app/src/main/java/org/buffer/android/biscotti/BiscottiUtil.kt#L44) - Verify an Intent with a given Matcher is launched
 
 Using Biscotti
 --------------

--- a/app/src/main/java/org/buffer/android/biscotti/BiscottiIntents.kt
+++ b/app/src/main/java/org/buffer/android/biscotti/BiscottiIntents.kt
@@ -1,0 +1,37 @@
+package org.buffer.android.biscotti
+
+import android.app.Instrumentation
+import android.content.Intent
+import android.support.test.espresso.intent.Intents
+import android.support.test.espresso.intent.Intents.intended
+import android.support.test.espresso.intent.Intents.intending
+import android.support.test.espresso.intent.matcher.IntentMatchers
+import android.support.test.espresso.intent.matcher.IntentMatchers.hasAction
+import android.support.test.espresso.intent.matcher.IntentMatchers.hasData
+import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.Matcher
+
+object BiscottiIntents {
+
+    fun verifyLinkOpen(expectedUrl: String, openLink: () -> Unit) {
+        val expectedIntent = allOf(hasAction(Intent.ACTION_VIEW), hasData(expectedUrl))
+        Intents.init()
+        verifyExpectedIntent(expectedIntent, openLink)
+    }
+
+    fun verifyActivityLaunched(className: String, startActivity: () -> Unit) {
+        val expectedIntent = IntentMatchers.hasComponent(className)
+        verifyExpectedIntent(expectedIntent, startActivity)
+    }
+
+    fun verifyExpectedIntent(expectedIntent: Matcher<Intent>?, startIntent: () -> Unit) {
+        Intents.init()
+        intending(expectedIntent).respondWith(Instrumentation.ActivityResult(0, null))
+        try {
+            startIntent()
+            intended(expectedIntent)
+        } finally {
+            Intents.release()
+        }
+    }
+}

--- a/app/src/main/java/org/buffer/android/biscotti/BiscottiUtil.kt
+++ b/app/src/main/java/org/buffer/android/biscotti/BiscottiUtil.kt
@@ -1,19 +1,9 @@
 package org.buffer.android.biscotti
 
-import android.app.Instrumentation
-import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.os.SystemClock
 import android.support.test.espresso.Espresso
-import android.support.test.espresso.intent.Intents
-import android.support.test.espresso.intent.Intents.intended
-import android.support.test.espresso.intent.Intents.intending
-import android.support.test.espresso.intent.matcher.IntentMatchers
-import android.support.test.espresso.intent.matcher.IntentMatchers.hasAction
-import android.support.test.espresso.intent.matcher.IntentMatchers.hasData
 import android.support.test.rule.ActivityTestRule
-import org.hamcrest.CoreMatchers.allOf
-import org.hamcrest.Matcher
 
 object BiscottiUtil {
 
@@ -28,27 +18,5 @@ object BiscottiUtil {
     fun closeSoftKeyboardWithDelay(delay: Long) {
         Espresso.closeSoftKeyboard()
         SystemClock.sleep(delay)
-    }
-
-    fun verifyLinkOpen(expectedUrl: String, openLink: () -> Unit) {
-        val expectedIntent = allOf(hasAction(Intent.ACTION_VIEW), hasData(expectedUrl))
-        Intents.init()
-        verifyExpectedIntent(expectedIntent, openLink)
-    }
-
-    fun verifyActivityLaunched(className: String, startActivity: () -> Unit) {
-        val expectedIntent = IntentMatchers.hasComponent(className)
-        verifyExpectedIntent(expectedIntent, startActivity)
-    }
-
-    fun verifyExpectedIntent(expectedIntent: Matcher<Intent>?, startIntent: () -> Unit) {
-        Intents.init()
-        intending(expectedIntent).respondWith(Instrumentation.ActivityResult(0, null))
-        try {
-            startIntent()
-            intended(expectedIntent)
-        } finally {
-            Intents.release()
-        }
     }
 }

--- a/app/src/main/java/org/buffer/android/biscotti/BiscottiUtil.kt
+++ b/app/src/main/java/org/buffer/android/biscotti/BiscottiUtil.kt
@@ -8,10 +8,12 @@ import android.support.test.espresso.Espresso
 import android.support.test.espresso.intent.Intents
 import android.support.test.espresso.intent.Intents.intended
 import android.support.test.espresso.intent.Intents.intending
+import android.support.test.espresso.intent.matcher.IntentMatchers
 import android.support.test.espresso.intent.matcher.IntentMatchers.hasAction
 import android.support.test.espresso.intent.matcher.IntentMatchers.hasData
 import android.support.test.rule.ActivityTestRule
 import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.Matcher
 
 object BiscottiUtil {
 
@@ -29,11 +31,21 @@ object BiscottiUtil {
     }
 
     fun verifyLinkOpen(expectedUrl: String, openLink: () -> Unit) {
-        Intents.init()
         val expectedIntent = allOf(hasAction(Intent.ACTION_VIEW), hasData(expectedUrl))
+        Intents.init()
+        verifyExpectedIntent(expectedIntent, openLink)
+    }
+
+    fun verifyActivityLaunched(className: String, startActivity: () -> Unit) {
+        val expectedIntent = IntentMatchers.hasComponent(className)
+        verifyExpectedIntent(expectedIntent, startActivity)
+    }
+
+    fun verifyExpectedIntent(expectedIntent: Matcher<Intent>?, startIntent: () -> Unit) {
+        Intents.init()
         intending(expectedIntent).respondWith(Instrumentation.ActivityResult(0, null))
         try {
-            openLink()
+            startIntent()
             intended(expectedIntent)
         } finally {
             Intents.release()


### PR DESCRIPTION
Add verification for opening an Activity, as well as a verification that can take a custom intent matcher.

Because this created a collection of Intent functions, I broke them out into their own object.

Could I get advice on the naming and documentation wording?